### PR TITLE
don't use port forwarding with Virtualbox

### DIFF
--- a/.idea/runConfigurations/debug_uber_docker_container.xml
+++ b/.idea/runConfigurations/debug_uber_docker_container.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="debug uber docker container" type="PyRemoteDebugConfigurationType" factoryName="Python Remote Debug" singleton="true">
     <module name="" />
     <option name="PORT" value="5000" />
-    <option name="HOST" value="10.0.0.29" />
+    <option name="HOST" value="10.0.2.2" />
     <PathMappingSettings>
       <option name="pathMappings">
         <list>
@@ -11,7 +11,7 @@
       </option>
     </PathMappingSettings>
     <option name="REDIRECT_OUTPUT" value="true" />
-    <option name="SUSPEND_AFTER_CONNECT" value="false" />
+    <option name="SUSPEND_AFTER_CONNECT" value="true" />
     <method />
   </configuration>
 </component>

--- a/DEV-SETUP.md
+++ b/DEV-SETUP.md
@@ -32,17 +32,31 @@ vagrant up
 
 6) Now that you have a build of the current code, all you need to do is run it.
 
+First, login to the virtual machine:
 ```
 vagrant ssh
+```
+
+Then, get the IP address of this machine, you will later type this into your browser:
+```
+which_ip
+```
+
+Bring up the entire app!
+```
 cd docker
 docker-compose up
 ```
 
-This will start the uber app in a container, and the code will be accessible from the OS running Vagrant (i.e. Windows) in app/uber/
+This will start the uber app, database, and other stuff in a container, and the code will be accessible 
+from the OS running Vagrant (i.e. Windows) in app/uber/
 
-7) Open your brower and go to "http://localhost:8282/uber/"
+7) Open your brower and using the IP you typed in earlier, go to the following URL in a browser:  
 
-You've installed it!
+Example, if the IP from the 'which_ip' command is 1.2.3.4 type this:
+```
+http://1.2.3.4:8282/
+```
 
 Inserting an admin user
 ======

--- a/DEV-SETUP.md
+++ b/DEV-SETUP.md
@@ -64,7 +64,7 @@ Inserting an admin user
 From inside vagrant, press CTRL+Z and then type in the following to insert an admin user:
 
 ```
-docker exec uberdocker_web_1 /uber/env/bin/sep insert_admin
+docker exec docker_web_1 /uber/env/bin/sep insert_admin
 ```
 
 Now you can login to the web app with username "magfest@example.com" and password "magfest"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,23 +6,26 @@ Vagrant.require_version ">= 1.6.2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.box = "ubuntu/trusty64"
 
-    config.vm.network :forwarded_port, guest: 8282, host: 8282
-    config.vm.network :forwarded_port, guest: 80, host: 8000
-    config.vm.network :forwarded_port, guest: 4443, host: 4443
-
-    # uncomment for private network 
-    # (useful if doing SMB or NFS shares FROM the guest OS -to- host OS
-    # config.vm.network "private_network", type: "dhcp"
-
-    # uncomment to enable SMB filesharing which is WAY faster than
-    # Virtualbox's shared folders which are SLOOOOOOOOOOOOOOOOW.
-    # note: symlinks don't work then.
-    # note2: SMB is also kind of unstable, so probably don't use it.
+    # setup a public network for Vagrant
+    # i.e. the VM will act as though it's another machine on your internal network
+    # this is insecure because it exposes this machine to the entire world, however,
+    # if you're behind a firewall it's like running this machine on a computer behind the firewall.
     #
-    # if Vagrant::Util::Platform.windows?
-    #    config.vm.synced_folder ".", "/home/vagrant/uber", type: "smb"
-    # else
-    # non-SMB share VBOXfs (stable, but slow as hell)
+    # IMPORTANT NOTE: We switched from the default NAT+port forwarding because
+    # Virtualbox's port forwarding has some serious bugs in it that interact badly with Docker.
+    # Do not use port forwarding to access applications running inside the
+    # Vagrant VM (especially Docker containers)
+    #
+    # This is discussed here:
+    # https://github.com/boot2docker/boot2docker-cli/issues/164
+    # https://groups.google.com/forum/#!topic/docker-user/bvZdFqQnUK8 <-- we were experiencing this content-length error
+    #
+    config.vm.network "public_network", type: "dhcp"
+
+
+    # Share the root folder into the host OS.
+    # this uses vboxfs to share stuff. it's stable, but slow as hell on windows.
+    # fortunately with Docker, we're not doing too much in the shared folder
     config.vm.synced_folder ".", "/home/vagrant/docker"
     # end
 

--- a/vagrant/bashrc
+++ b/vagrant/bashrc
@@ -1,0 +1,2 @@
+# print out the IP address of eth1, which is what the developer will type into a browser to access the app
+alias which_ip="ifconfig eth1 | grep 'inet addr' | cut -f 2 -d ':' | cut -f 1 -d ' '"

--- a/vagrant/vagrant.sh
+++ b/vagrant/vagrant.sh
@@ -13,3 +13,6 @@ build/build.sh
 # windows-only: tell all git repos to ignore file permissions, which are 
 # broken on vagrant shared folders from windows. (doesn't affect *nix)
 vagrant/set-git-ignore-permissions.sh
+
+# setup some bash aliases/etc
+cp vagrant/bashrc ~/.bashrc


### PR DESCRIPTION
as I discovered the hard way, Virtualbox port forwarding + Docker port forwarding interacts badly and randomly messes up HTTP requests (yes, really).

this manifests with a bunch of err::CONTENT_TYPE_LENGTH_MISMATCH errors.

this is fixed by simply not doing port forwarding and only doing host-only networking.
this is one shade less convenient for dev deployments as the user needs to learn the IP address of the container
this does inadvertently allow for one cool thing (Bob will be stoked): you can now access the VMs for testing from another computer

more details:
https://github.com/boot2docker/boot2docker-cli/issues/164 <-- boot2docker recommends same thing
https://groups.google.com/forum/#!topic/docker-user/bvZdFqQnUK8 <-- we were experiencing this content-length error

TODO:
before merging, need to update the docs to tell people to find the IP of the host machine via SSH (which still works with 'vagrant ssh') and use that for their browser
