### PR TITLE
workaround weird ubuntu apt-get ipv6 bug

### DIFF
--- a/setup/setup-docker.sh
+++ b/setup/setup-docker.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 
-# installs latest docker and docker-compose
+# this script installs latest docker and docker-compose
+
+
+# workaround a weird ubuntu bug where sometimes ubuntu hangs on apt-get update
+# during the docker install.  set affinity to use ipv4 where possible.
+# this wasn't originally a problem, but started happening.
+echo -en "# DOCKER: fot sites which prefer IPv4 connections\nprecedence ::ffff:0:0/96  100" >> /etc/gai.conf
+
 
 command_exists() {
 	command -v "$@" > /dev/null 2>&1

--- a/vagrant/vagrant.sh
+++ b/vagrant/vagrant.sh
@@ -15,4 +15,4 @@ build/build.sh
 vagrant/set-git-ignore-permissions.sh
 
 # setup some bash aliases/etc
-cp vagrant/bashrc ~/.bash_aliases
+cp vagrant/bashrc /home/vagrant/.bash_aliases


### PR DESCRIPTION
on my older laptop, this is suddenly required.
on my newer desktop, it still works fine without it.
this is some kind of weird interaction with ipv6, detailed here:
http://askubuntu.com/questions/574569/apt-get-stuck-at-0-connecting-to-us-archive-ubuntu-com

since this is a one-liner I'm going to merge it in, just wanted you guys to see it.

unrelated: one-line fix that makes 'which_ip' work again.
