### PR TITLE
Fix 'ini missing' errors when building web container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ src
 src/*
 nginx/certs
 uber-development.ini
-sideboard-development.ini

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM ramsproject/rams
 
 ADD src plugins/
 ADD sideboard-development.ini ./development.ini
-ADD uber-development.ini plugins/uber/development.ini
 RUN /app/env/bin/paver install_deps
 
 # derp, fix this to be done in sideboard instead

--- a/docker-staging.yml
+++ b/docker-staging.yml
@@ -7,11 +7,14 @@ web:
     - redis
   ports:
     - "80:8282"
+  environment:
+    - DB_CONNECTION_STRING=postgresql://rams:testdb@rams_db:5432/rams
 db:
   image: postgres
+  container_name: rams_db
   environment:
-    - POSTGRES_PASSWORD=uber_db
-    - POSTGRES_USER=uber_db
-    - POSTGRES_DB=uber_db
+    - POSTGRES_PASSWORD=testdb
+    - POSTGRES_USER=rams
+    - POSTGRES_DB=rams
 redis:
   image: redis

--- a/sideboard-development.ini
+++ b/sideboard-development.ini
@@ -1,0 +1,8 @@
+debug = false
+priority_plugins = uber
+default_url = "/rams"
+
+[cherrypy]
+server.socket_host = 0.0.0.0
+server.socket_port = 8282
+tools.sessions.timeout = 4320  # 30 days (in minutes)

--- a/sideboard-development.ini
+++ b/sideboard-development.ini
@@ -1,5 +1,5 @@
 debug = false
-priority_plugins = uber
+priority_plugins = uber,
 default_url = "/rams"
 
 [cherrypy]


### PR DESCRIPTION
For some reason, we had a Dockerfile that was expecting files that weren't being checked in. This is bad for user experience - quickstart shouldn't need you to manually create files for it to work.

Docker doesn't seem to have a way to put conditionals in Dockerfiles, so the best way to solve this is to include the file in the repo.

This is pretty much doable with the sideboard-development.ini file, as it doesn't have much in it. uber-development.ini was a different story, and because a developer's instinct would be to edit development.ini inside the uber plugin anyway, I took that line out.

This is an imperfect fix but it was blocking another developer, so I wanted to get SOMEthing out there. Suggestions are welcome.
