### PR TITLE
Fixed extraneous ADD statement

### DIFF
--- a/lb/Dockerfile
+++ b/lb/Dockerfile
@@ -1,2 +1,1 @@
 FROM jwilder/nginx-proxy
-ADD certs/* /etc/nginx/certs/


### PR DESCRIPTION
The ADD blocks the setup unless you create the dir and put a dummy file in it.  Since you're just creating dummy files, leave it out for now, and put the statement back in when you need to copy some certs.