### PR TITLE
PyCharm remote debugging support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,30 @@
 FROM ramsproject/rams
 
+#ENV SFTP_USER docker
+#ENV SFTP_PASS changeme
+#ENV PASS_ENCRYPTED false
+
+##################################################
+# Add SSH/SFTP support so PyCharm can connect    #
+# Note, we only do this on the developer install #
+##################################################
+RUN \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get -y install openssh-server && \
+    rm -rf /var/lib/apt/lists/*
+# sshd needs this directory to run
+RUN mkdir -p /var/run/sshd
+ADD sshd_config /etc/ssh/sshd_config
+ADD entrypoint /
+EXPOSE 22
+# entrypoint script starts sshd and then Sideboard
+ENTRYPOINT ["/entrypoint"]
+
+##########################################################
+# Add our local plugins and install any new dependencies #
+# that weren't already on the Docker Hub image           #
+# This is done LAST so builds can be cached properly     #
+##########################################################
 ADD src plugins/
 ADD sideboard-development.ini ./development.ini
 RUN /app/env/bin/paver install_deps
-
-# derp, fix this to be done in sideboard instead
-CMD /app/env/bin/python3 /app/sideboard/run_server.py

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,22 +8,28 @@ lb:
     - "443:443"
   volumes:
     - /var/run/docker.sock:/tmp/docker.sock:ro
+  container_name: rams_lb
   environment:
     - DEFAULT_HOST=rams.local
 web:
   build: .
   links:
     - db
-    - redis
   expose:
     - "8282"
+  ports:
+    - "22:22"
   volumes:
     - ./src:/app/plugins
   restart: always
+  container_name: rams_web
   environment:
     - DB_CONNECTION_STRING=postgresql://uber_db:uber_db@rams_db:5432/uber_db
     - VIRTUAL_HOST=rams.local
     - CERT_NAME=ssl
+    - SFTP_USER=rams
+    - SFTP_PASS=rams
+    - PASS_ENCRYPTED=false
 db:
   image: postgres
   container_name: rams_db
@@ -31,5 +37,3 @@ db:
     - POSTGRES_PASSWORD=uber_db
     - POSTGRES_USER=uber_db
     - POSTGRES_DB=uber_db
-redis:
-  image: redis

--- a/entrypoint
+++ b/entrypoint
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# creating user. Default ist user=docker, pass=changeme
+# can be changed by setting ENV Variables SFTP_USER, SFTP_PASS
+user="${SFTP_USER}"
+pass="${SFTP_PASS}"
+
+if [ "${PASS_ENCRYPTED}" == "true" ]; then
+    chpasswdOptions="-e"
+fi
+
+useraddOptions="--create-home --shell /bin/bash"
+
+if [ -n "${USER_UID}" ]; then
+    useraddOptions="$useraddOptions --non-unique --uid ${USER_UID}"
+fi
+
+if [ -n "${USER_GID}" ]; then
+    useraddOptions="$useraddOptions --gid ${USER_GID}"
+    groupadd --gid ${USER_GID} ${USER_GID}
+fi
+
+useradd $useraddOptions $user
+chown $user:$user /home/$user
+chmod 755 /home/$user
+
+# TODO: get public key authorization to work
+mkdir /home/$user/.ssh
+chmod 700 /home/$user/.ssh
+
+if [ -z "$pass" ]; then
+    pass="$(echo `</dev/urandom tr -dc A-Za-z0-9 | head -c256`)"
+    chpasswdOptions=""
+fi
+
+echo "$user:$pass" | chpasswd $chpasswdOptions
+
+# starting ssh (detached)
+exec /etc/init.d/ssh start &
+exec /app/env/bin/python3 /app/sideboard/run_server.py

--- a/sshd_config
+++ b/sshd_config
@@ -1,0 +1,82 @@
+# TODO: this could use some cleanup...
+
+# der Port auf dem der ssh Server auf Verbindungen "warten" soll
+Port 22
+
+# Wenn AllowUsers definiert wurde, dann ist das anmelden auf dem SSH Server nur diesen Usern erlaubt.
+# Man kann mehrere User angeben. Sie werden dann durch Leerzeichen getrennt.
+#AllowUsers SystemUsername
+
+# Mit der aktuellen Version ist nur noch SSH2 erlaubt, aber bei älteren Versionen wäre auch SSH1 möglich.
+# Mit der Angabe von Protocol 2 beschränkt man es aber auf SSH2.
+Protocol 2
+
+# Mit ListenAddress kann man angeben an welchen Interfaces der sshd lauschen soll.
+# Der Standard 0.0.0.0 lauscht an alles verfügbaren Interfaces.
+# Man sollte es auf 1 Interface beschränken.
+ListenAddress 0.0.0.0
+
+# Der Pfad zum private Key
+HostKey /etc/ssh/ssh_host_rsa_key
+HostKey /etc/ssh/ssh_host_dsa_key
+
+# Logging
+SyslogFacility AUTH
+LogLevel INFO
+
+# Wenn aktiviert, dann wird eine eingehende Verbindung vom Hauptprozess getrennt.
+# Außerdem läuft sie dann unter den Rechten das angemeldeten Users.
+# Default ist yes und so sollte es auch bleiben.
+UsePrivilegeSeparation yes
+
+# Nach den hier angegebenen Sekunden wird die Verbindung getrennt
+# wenn der User sich nicht erfolgreich angemeldet hat
+LoginGraceTime 120
+
+# Mit PermitRootLogin kann man dem User root verbieten sich per SSH anzumelden.
+# Auch das ist eine Sicherheitseinstellung die Bruteforce Attacken auf den root User verhindern soll.
+# no = keine Rootanmeldung per SSH erlaubt | yes = root kann sich anmelden
+PermitRootLogin no
+
+# Überprüft die Besitzrechte der Userdateien und des Homedirs bevor sich ein User anmelden kann
+StrictModes yes
+
+# Erlaubt Public Key Authentification
+# Default ist yes, wenn man es nicht benutzt kann man es auch abschalten
+PubkeyAuthentication no
+
+# Erlaubt die Anmeldung mit Passwörtern. Bevor man dies abschaltet, sollte man einen anderen Weg haben!
+PasswordAuthentication yes
+
+# Da es nur Protocol Version 1 betrifft ist es nicht wichtig zu setzen.
+# Am besten man setzt es trotzdem, aber dann auf no!
+RSAAuthentication no
+
+# Es sollen keine ~/.rhosts und ~/.shosts Dateien im Homedir geladen werden
+IgnoreRhosts yes
+
+# Auch ein Überbleibsel von SSH1. No ist richtig!
+RhostsRSAAuthentication no
+
+# Eine vergleichbare Funktion von RhostsRSAAuthentication, aber für SSH2.
+# Hab ich noch nie gebraucht.
+HostbasedAuthentication no
+
+# Wenn man es auch yes setzt, kann man sich mit leeren Passwörtern anmelden.
+# Da sagt der gesunde Menschenverstand schon etwas anderes.
+PermitEmptyPasswords no
+
+# Ist ein Brutforce Schutz, der die maximalen unautorisierten Verbindungen steuert.
+MaxStartups 10:30:60
+
+# Aktiviert das Subsystem sftp
+#Subsystem   sftp    /usr/lib/openssh/sftp-server
+Subsystem sftp internal-sftp
+
+# Wenn man dies auf yes setzt wird einem User die /etc/motd angezeigt wenn er sich verbindet.
+PrintMotd no
+
+# Diese Settings sollten selbsterklärend sein.
+KeepAlive yes
+PrintLastLog yes
+UsePAM yes


### PR DESCRIPTION
This is a WIP. Still needs documentation, updating the `.idea` files, and possibly better error handling.

However, it's possible to add this locally. Add a remote interpreter to your project, localhost:22 rams/rams and it should Just Work. It does for me.

Note - do NOT deploy this anywhere port 22 is open to the world. The password on the container is pretty trivial in this initial commit.